### PR TITLE
Change SelectedItems to HashSet, add SelectMany method

### DIFF
--- a/VirtualListView/IVirtualListView.cs
+++ b/VirtualListView/IVirtualListView.cs
@@ -22,7 +22,7 @@ public interface IVirtualListView : IView
 
 	SelectionMode SelectionMode { get; }
 
-	IList<ItemPosition> SelectedItems { get; set; }
+	ISet<ItemPosition> SelectedItems { get; set; }
 
 	ItemPosition? SelectedItem { get; set; }
 	

--- a/VirtualListView/ItemPosition.cs
+++ b/VirtualListView/ItemPosition.cs
@@ -15,4 +15,6 @@ public struct ItemPosition : IEquatable<ItemPosition>
 
 	public bool Equals(ItemPosition other)
 		=> SectionIndex == other.SectionIndex && ItemIndex == other.ItemIndex;
+    public override int GetHashCode()
+		=> SectionIndex * 16 + ItemIndex;
 }


### PR DESCRIPTION
I was noticing very poor performance when trying to implement a "Select All" button for lists of ~5000 elements. Refactoring SelectedItems to use a HashSet provides major performance improvements. Also added a SelectMany method that only updates the property once.